### PR TITLE
adds missing attr_accessors to AuthorizeNet::Order class

### DIFF
--- a/lib/authorize_net/order.rb
+++ b/lib/authorize_net/order.rb
@@ -1,12 +1,13 @@
 module AuthorizeNet
-  
+
   # Models an order.
   class Order
-    
+
     include AuthorizeNet::Model
-    
-    attr_accessor :invoice_num, :description, :tax, :tax_name, :tax_description, :freight, :freight_name, :freight_description, :duty, :duty_name, :duty_description, :tax_exempt, :po_num, :line_items
-    
+
+    attr_accessor :invoice_num, :description, :tax, :tax_amount, :tax_name, :tax_description, :freight, :freight_name, :freight_description, :duty, :duty_amount, :duty_name, :duty_description, :tax_exempt, :po_num, :line_items
+    attr_accessor :shipping_amount, :shipping_name, :shipping_description
+
     def add_line_item(id = nil, name = nil, description = nil, quantity = nil, price = nil, taxable = nil)
       if id.kind_of?(AuthorizeNet::LineItem)
         line_item = id
@@ -15,20 +16,25 @@ module AuthorizeNet
       end
       @line_items = @line_items.to_a << line_item
     end
-    
+
     def to_hash
       hash = {
         :invoice_num => @invoice_num,
         :description => @description,
         :tax => @tax,
+        :tax_amount => @tax_amount,
         :tax_name => @tax_name,
         :tax_description => @tax_description,
         :freight => @freight,
         :freight_name => @freight_name,
         :freight_description => @freight_description,
         :duty => @duty,
+        :duty_amount => @duty_amount,
         :duty_name => @duty_name,
         :duty_description => @duty_description,
+        :shipping_amount => @shipping_amount,
+        :shipping_name => @shipping_name,
+        :shipping_description => @shipping_description,
         :tax_exempt => @tax_exempt,
         :po_num => @po_num,
         :line_items => handle_multivalue_hashing(@line_items)
@@ -36,7 +42,7 @@ module AuthorizeNet
       hash.delete_if {|k, v| v.nil?}
       hash
     end
-    
+
   end
-  
+
 end

--- a/spec/reporting_spec.rb
+++ b/spec/reporting_spec.rb
@@ -368,6 +368,21 @@ describe AuthorizeNet::Reporting do
           </order>
           <authAmount>10.00</authAmount>
           <settleAmount>10.00</settleAmount>
+          <tax>
+            <amount>0.00</amount>
+            <name>tax name</name>
+            <description>tax description</description>
+          </tax>
+          <shipping>
+            <amount>0.00</amount>
+            <name>shipping name</name>
+            <description>shipping description</description>
+          </shipping>
+          <duty>
+            <amount>0.00</amount>
+            <name>duty name</name>
+            <description>duty description</description>
+          </duty>
           <lineItems>
             <lineItem>
               <itemId>ITEM00001</itemId>
@@ -437,6 +452,18 @@ describe AuthorizeNet::Reporting do
       transaction.order.line_items.length.should == 2
       transaction.order.line_items[0].should be_kind_of(AuthorizeNet::LineItem)
       transaction.order.tax_exempt.should be_falsey
+
+      transaction.order.tax_amount.should == 0.00
+      transaction.order.tax_name.should == 'tax name'
+      transaction.order.tax_description.should == 'tax description'
+
+      transaction.order.duty_amount.should == 0.00
+      transaction.order.duty_name.should == 'duty name'
+      transaction.order.duty_description.should == 'duty description'
+
+      transaction.order.shipping_amount.should == 0.00
+      transaction.order.shipping_name.should == 'shipping name'
+      transaction.order.shipping_description.should == 'shipping description'
 
       transaction.payment_method.should be_kind_of(AuthorizeNet::CreditCard)
       transaction.payment_method.card_number.should == 'XXXX1111'


### PR DESCRIPTION
addresses issues in #526 of spacewalk repo

It's probably going to take a while for AuthorizeNet to merge these fixes to their gem, so we forked it and are going to use our own version until they merge the fixes.